### PR TITLE
Add TPB research client project

### DIFF
--- a/tpb/.gitignore
+++ b/tpb/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+.pytest_cache/
+__pycache__/
+.python-version
+.DS_Store

--- a/tpb/README.md
+++ b/tpb/README.md
@@ -1,0 +1,36 @@
+# tpb
+
+A research-focused terminal client for The Pirate Bay. The package provides:
+
+- A Python API (`TPBClient`) for querying TPB mirrors (Tor by default)
+- A JSON helper for easy data export
+- A Textual TUI for interactive searching
+- A Typer-powered CLI that can output tables or JSON
+
+## Quickstart
+
+Install dependencies with [uv](https://docs.astral.sh/uv/):
+
+```bash
+uv sync
+```
+
+Search from the CLI (Tor on by default):
+
+```bash
+uv run tpb search "ubuntu" --limit 5 --json
+```
+
+Launch the TUI:
+
+```bash
+uv run tpb tui --query "ubuntu"
+```
+
+## Development
+
+Run the test suite:
+
+```bash
+uv run pytest
+```

--- a/tpb/main.py
+++ b/tpb/main.py
@@ -1,0 +1,5 @@
+from tpb.cli import main
+
+
+if __name__ == "__main__":
+    main()

--- a/tpb/pyproject.toml
+++ b/tpb/pyproject.toml
@@ -18,3 +18,10 @@ tpb = "tpb.cli:main"
 dev = [
     "pytest>=9.0.1",
 ]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.uv]
+package = true

--- a/tpb/pyproject.toml
+++ b/tpb/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "tpb"
+version = "0.1.0"
+description = "Research-focused terminal client for The Pirate Bay"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "pysocks>=1.7.1",
+    "python-gnupg>=0.5.5",
+    "textual>=6.6.0",
+    "typer>=0.20.0",
+]
+
+[project.scripts]
+tpb = "tpb.cli:main"
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.1",
+]

--- a/tpb/tests/conftest.py
+++ b/tpb/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tpb/tests/test_client.py
+++ b/tpb/tests/test_client.py
@@ -1,0 +1,105 @@
+from urllib import error
+from unittest import mock
+
+import pytest
+
+from tpb.client import TPBClient
+from tpb.exceptions import MirrorError, SearchError, VerificationError
+from tpb.models import Torrent
+
+
+SAMPLE_HTML = """
+<table id="searchResult">
+<tr>
+<td>
+    <div class="detName"><a class="detLink" href="/torrent/1">Sample Torrent</a></div>
+    <a href="magnet:?xt=urn:btih:example">Magnet</a>
+    <font class="detDesc">Uploaded 01-01, Size 1.23 GiB, ULed by uploader1</font>
+</td>
+<td align="right">120</td>
+<td align="right">55</td>
+</tr>
+</table>
+"""
+
+
+def build_mock_opener(html: str | Exception):
+    opener = mock.Mock()
+    if isinstance(html, Exception):
+        opener.open.side_effect = html
+    else:
+        response = mock.Mock()
+        response.read.return_value = html.encode()
+        response.__enter__ = lambda s: s
+        response.__exit__ = mock.Mock()
+        opener.open.return_value = response
+    return opener
+
+
+def test_search_happy_path(monkeypatch):
+    mock_opener = build_mock_opener(SAMPLE_HTML)
+    monkeypatch.setattr("tpb.client.request.build_opener", lambda *_: mock_opener)
+
+    client = TPBClient(mirrors=["https://mirror.example"], use_tor=False)
+    results = client.search("ubuntu", limit=5)
+
+    assert len(results) == 1
+    assert results[0] == Torrent(
+        title="Sample Torrent",
+        magnet="magnet:?xt=urn:btih:example",
+        seeders=120,
+        leechers=55,
+        size="1.23 GiB",
+        uploader="uploader1",
+    )
+
+
+def test_all_mirrors_fail(monkeypatch):
+    error_instance = error.URLError("timeout")
+    mock_opener = build_mock_opener(error_instance)
+    monkeypatch.setattr("tpb.client.request.build_opener", lambda *_: mock_opener)
+
+    client = TPBClient(mirrors=["https://mirror.example"], use_tor=False)
+    with pytest.raises(SearchError):
+        client.search("ubuntu")
+
+
+def test_onion_requires_tor():
+    with pytest.raises(MirrorError):
+        TPBClient(onion_mirror="http://example.onion", use_tor=False)
+
+
+def test_pgp_strict_failure(monkeypatch):
+    mock_gpg = mock.Mock()
+    mock_gpg.verify_data.return_value = mock.Mock(valid=False)
+    monkeypatch.setattr("tpb.client.gnupg.GPG", lambda: mock_gpg)
+
+    monkeypatch.setattr("tpb.client.TPBClient._fetch", lambda *_, **__: "data")
+
+    with pytest.raises(VerificationError):
+        TPBClient(
+            onion_mirror="http://example.onion",
+            use_tor=True,
+            pgp_check=True,
+            pgp_public_key="KEY",
+            allow_unverified_onion=False,
+        )
+
+
+def test_tor_enabled_by_default(monkeypatch):
+    captured_proxies = {}
+
+    def fake_proxy_handler(proxies):
+        nonlocal captured_proxies
+        captured_proxies = proxies
+        return "proxy-handler"
+
+    monkeypatch.setattr("tpb.client.request.ProxyHandler", fake_proxy_handler)
+    monkeypatch.setattr("tpb.client.request.build_opener", lambda *handlers: handlers[0])
+
+    client = TPBClient()
+    assert client._opener == "proxy-handler"
+    assert captured_proxies == {
+        "http": "socks5h://127.0.0.1:9050",
+        "https": "socks5h://127.0.0.1:9050",
+    }

--- a/tpb/tests/test_json_utils.py
+++ b/tpb/tests/test_json_utils.py
@@ -1,0 +1,31 @@
+import json
+
+from tpb.json_utils import torrents_to_json
+from tpb.models import Torrent
+
+
+def test_torrents_to_json():
+    torrents = [
+        Torrent(
+            title="Example",
+            magnet="magnet:?xt=urn:btih:example",
+            seeders=10,
+            leechers=2,
+            size="700 MiB",
+            uploader="user",
+        )
+    ]
+
+    output = torrents_to_json(torrents)
+    payload = json.loads(output)
+
+    assert payload == [
+        {
+            "title": "Example",
+            "magnet": "magnet:?xt=urn:btih:example",
+            "seeders": 10,
+            "leechers": 2,
+            "size": "700 MiB",
+            "uploader": "user",
+        }
+    ]

--- a/tpb/tpb/__init__.py
+++ b/tpb/tpb/__init__.py
@@ -1,0 +1,13 @@
+"""Research-oriented terminal client for The Pirate Bay."""
+
+from .client import TPBClient
+from .exceptions import MirrorError, SearchError, VerificationError
+from .models import Torrent
+
+__all__ = [
+    "TPBClient",
+    "Torrent",
+    "MirrorError",
+    "SearchError",
+    "VerificationError",
+]

--- a/tpb/tpb/cli.py
+++ b/tpb/tpb/cli.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from .client import TPBClient
+from .exceptions import MirrorError, SearchError, VerificationError
+from .json_utils import torrents_to_json
+from .tui import TPBTuiApp
+
+app = typer.Typer(help="Research-oriented terminal client for The Pirate Bay")
+
+
+def _load_pgp_key(path: Optional[Path]) -> Optional[str]:
+    if path is None:
+        return None
+    return path.read_text(encoding="utf-8")
+
+
+def _print_table(rows):
+    headers = ["Idx", "Title", "Seeders", "Leechers", "Size", "Uploader"]
+    table = [headers]
+    for idx, torrent in enumerate(rows, start=1):
+        table.append(
+            [
+                str(idx),
+                torrent.title,
+                str(torrent.seeders),
+                str(torrent.leechers),
+                torrent.size,
+                torrent.uploader,
+            ]
+        )
+
+    column_widths = [max(len(row[col]) for row in table) for col in range(len(headers))]
+
+    def format_row(row):
+        return " | ".join(cell.ljust(column_widths[i]) for i, cell in enumerate(row))
+
+    divider = "-+-".join("-" * width for width in column_widths)
+    typer.echo(format_row(headers))
+    typer.echo(divider)
+    for row in table[1:]:
+        typer.echo(format_row(row))
+
+
+@app.command()
+def search(
+    query: str,
+    limit: int = typer.Option(10, help="Maximum number of results to return"),
+    tor: bool = typer.Option(True, "--tor/--no-tor", help="Use Tor for requests"),
+    onion: bool = typer.Option(False, "--onion/--no-onion", help="Prefer the default onion mirror"),
+    onion_mirror: Optional[str] = typer.Option(None, help="Override onion mirror URL"),
+    pgp_strict: bool = typer.Option(
+        False, "--pgp-strict/--no-pgp-strict", help="Require successful PGP verification for onions"
+    ),
+    pgp_key_file: Optional[Path] = typer.Option(None, help="Path to a PGP public key"),
+    output_json: bool = typer.Option(False, "--json/--no-json", help="Emit JSON instead of a table"),
+):
+    """Search TPB mirrors for a query."""
+
+    selected_onion = None
+    if onion:
+        selected_onion = onion_mirror or TPBClient.DEFAULT_ONION
+
+    pgp_key = _load_pgp_key(pgp_key_file)
+
+    client = TPBClient(
+        use_tor=tor,
+        onion_mirror=selected_onion,
+        pgp_check=pgp_key is not None,
+        pgp_public_key=pgp_key,
+        allow_unverified_onion=not pgp_strict,
+    )
+
+    try:
+        results = client.search(query=query, limit=limit)
+    except (SearchError, MirrorError, VerificationError) as exc:
+        raise typer.Exit(code=1) from exc
+
+    if output_json:
+        typer.echo(torrents_to_json(results))
+    else:
+        _print_table(results)
+
+
+@app.command()
+def tui(
+    query: Optional[str] = typer.Option(None, help="Optional initial search query"),
+    tor: bool = typer.Option(True, "--tor/--no-tor", help="Use Tor for requests"),
+):
+    """Launch the Textual TUI."""
+
+    client = TPBClient(use_tor=tor)
+    TPBTuiApp(client=client, initial_query=query).run()
+
+
+def main():
+    app()
+
+
+if __name__ == "__main__":
+    main()

--- a/tpb/tpb/client.py
+++ b/tpb/tpb/client.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import re
+from html.parser import HTMLParser
+from typing import Iterable
+from urllib import error, parse, request
+
+import gnupg
+
+from .exceptions import MirrorError, SearchError, VerificationError
+from .models import Torrent
+
+
+class _RowParser(HTMLParser):
+    def __init__(self, limit: int):
+        super().__init__()
+        self.limit = limit
+        self.rows: list[Torrent] = []
+        self._in_row = False
+        self._in_title = False
+        self._in_details = False
+        self._title_parts: list[str] = []
+        self._details_parts: list[str] = []
+        self._current: dict[str, str | int] = {}
+        self._align_right_index = 0
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]):
+        if tag == "tr":
+            if len(self.rows) >= self.limit:
+                return
+            self._in_row = True
+            self._current = {
+                "title": "",
+                "magnet": "",
+                "seeders": 0,
+                "leechers": 0,
+                "size": "Unknown",
+                "uploader": "Unknown",
+            }
+            self._title_parts = []
+            self._details_parts = []
+            self._align_right_index = 0
+            return
+
+        if not self._in_row:
+            return
+
+        attr_map = {key: value for key, value in attrs}
+
+        if tag == "a":
+            href = attr_map.get("href", "")
+            if href.startswith("magnet:"):
+                self._current["magnet"] = href
+            class_attr = attr_map.get("class", "") or ""
+            if "detLink" in class_attr.split():
+                self._in_title = True
+            return
+
+        if tag == "td":
+            align_value = (attr_map.get("align", "") or "").lower()
+            if align_value == "right":
+                self._align_right_index += 1
+            class_attr = attr_map.get("class", "") or ""
+            if "detDesc" in class_attr.split():
+                self._in_details = True
+            return
+
+        if tag == "font":
+            class_attr = attr_map.get("class", "") or ""
+            if "detDesc" in class_attr.split():
+                self._in_details = True
+
+    def handle_endtag(self, tag: str):
+        if tag == "a" and self._in_title:
+            self._in_title = False
+        if tag in {"td", "font"} and self._in_details:
+            self._in_details = False
+        if tag == "tr" and self._in_row:
+            if len(self.rows) < self.limit and self._current.get("magnet"):
+                title = " ".join(part for part in self._title_parts if part).strip()
+                details_text = " ".join(part for part in self._details_parts if part)
+                size, uploader = self._parse_details(details_text)
+                self._current["title"] = title
+                self._current["size"] = size
+                self._current["uploader"] = uploader
+                torrent = Torrent(
+                    title=title or "",
+                    magnet=str(self._current["magnet"]),
+                    seeders=int(self._current.get("seeders", 0)),
+                    leechers=int(self._current.get("leechers", 0)),
+                    size=str(self._current.get("size", "Unknown")),
+                    uploader=str(self._current.get("uploader", "Unknown")),
+                )
+                self.rows.append(torrent)
+            self._in_row = False
+
+    def handle_data(self, data: str):
+        if not self._in_row:
+            return
+        text = data.strip()
+        if not text:
+            return
+
+        if self._in_title:
+            self._title_parts.append(text)
+            return
+
+        if self._in_details:
+            self._details_parts.append(text)
+            return
+
+        if self._align_right_index == 1:
+            self._current["seeders"] = int(text) if text.isdigit() else 0
+        elif self._align_right_index == 2:
+            self._current["leechers"] = int(text) if text.isdigit() else 0
+
+    @staticmethod
+    def _parse_details(details: str) -> tuple[str, str]:
+        size_match = re.search(r"Size ([^,]+)", details)
+        uploader_match = re.search(r"ULed by ([^,]+)", details)
+        size = size_match.group(1).strip() if size_match else "Unknown"
+        uploader = uploader_match.group(1).strip() if uploader_match else "Unknown"
+        return size, uploader
+
+
+def _build_url(mirror: str, query: str, page: int, sort: int) -> str:
+    quoted_query = parse.quote(query)
+    base = mirror if mirror.endswith("/") else f"{mirror}/"
+    return parse.urljoin(base, f"search/{quoted_query}/{page}/{sort}/0")
+
+
+class TPBClient:
+    DEFAULT_MIRRORS = [
+        "https://thepiratebay.org",
+        "https://pirateproxy.live",
+        "https://tpb.party",
+    ]
+
+    DEFAULT_ONION = "http://uj3wazyk5u4hnvtk.onion"
+
+    def __init__(
+        self,
+        mirrors: Iterable[str] | None = None,
+        use_tor: bool = True,
+        timeout: int = 8,
+        onion_mirror: str | None = None,
+        pgp_check: bool = False,
+        pgp_public_key: str | None = None,
+        allow_unverified_onion: bool = False,
+    ):
+        if onion_mirror and not use_tor:
+            raise MirrorError("Onion mirrors require Tor to be enabled.")
+
+        self.use_tor = use_tor
+        self.timeout = timeout
+        self.onion_mirror = onion_mirror
+        self.pgp_check = pgp_check
+        self.pgp_public_key = pgp_public_key
+        self.allow_unverified_onion = allow_unverified_onion
+        self._onion_verified = True
+
+        self.mirrors = list(mirrors) if mirrors is not None else list(self.DEFAULT_MIRRORS)
+        if onion_mirror:
+            self.mirrors = [onion_mirror] + self.mirrors
+
+        self._opener = self._build_opener(use_tor)
+
+        if pgp_check and onion_mirror and pgp_public_key:
+            self._verify_onion()
+
+    def _build_opener(self, use_tor: bool):
+        proxies: dict[str, str] = {}
+        if use_tor:
+            proxies = {
+                "http": "socks5h://127.0.0.1:9050",
+                "https": "socks5h://127.0.0.1:9050",
+            }
+        proxy_handler = request.ProxyHandler(proxies)
+        return request.build_opener(proxy_handler)
+
+    def _fetch(self, url: str, *, head: bool = False) -> str:
+        req = request.Request(url)
+        if head:
+            req.get_method = lambda: "HEAD"
+        try:
+            with self._opener.open(req, timeout=self.timeout) as resp:
+                return resp.read().decode("utf-8", errors="replace")
+        except error.URLError as exc:  # pragma: no cover - exercised via mocks
+            raise MirrorError(str(exc)) from exc
+        except OSError as exc:  # pragma: no cover - exercised via mocks
+            raise MirrorError(str(exc)) from exc
+
+    def _verify_onion(self):
+        assert self.onion_mirror is not None
+        assert self.pgp_public_key is not None
+
+        gpg = gnupg.GPG()
+        gpg.import_keys(self.pgp_public_key)
+
+        resource_url = parse.urljoin(self.onion_mirror, "mirrors.txt")
+        signature_url = f"{resource_url}.asc"
+
+        resource = self._fetch(resource_url)
+        signature = self._fetch(signature_url)
+
+        verification = gpg.verify_data(signature, resource.encode("utf-8"))
+        is_valid = bool(verification) and getattr(verification, "valid", True)
+        if not is_valid:
+            self._onion_verified = False
+            if not self.allow_unverified_onion:
+                raise VerificationError("Onion mirror could not be verified via PGP.")
+
+    def search(
+        self,
+        query: str,
+        limit: int = 10,
+        sort: int = 99,
+        page: int = 0,
+    ) -> list[Torrent]:
+        errors: list[Exception] = []
+        for mirror in self.mirrors:
+            try:
+                url = _build_url(mirror, query, page, sort)
+                html = self._fetch(url)
+                rows = self._parse_rows(html, limit)
+                return rows[:limit]
+            except MirrorError as exc:
+                errors.append(exc)
+                continue
+        raise SearchError(f"All mirrors failed: {[str(e) for e in errors]}")
+
+    @staticmethod
+    def _parse_rows(html: str, limit: int) -> list[Torrent]:
+        parser = _RowParser(limit)
+        parser.feed(html)
+        return parser.rows

--- a/tpb/tpb/exceptions.py
+++ b/tpb/tpb/exceptions.py
@@ -1,0 +1,10 @@
+class SearchError(Exception):
+    """Raised when a search fails for all mirrors."""
+
+
+class MirrorError(Exception):
+    """Raised when a mirror is unreachable or invalid."""
+
+
+class VerificationError(Exception):
+    """Raised when PGP/onion verification fails."""

--- a/tpb/tpb/json_utils.py
+++ b/tpb/tpb/json_utils.py
@@ -1,0 +1,7 @@
+from dataclasses import asdict
+import json
+from .models import Torrent
+
+
+def torrents_to_json(torrents: list[Torrent]) -> str:
+    return json.dumps([asdict(t) for t in torrents], indent=2)

--- a/tpb/tpb/models.py
+++ b/tpb/tpb/models.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+
+@dataclass(slots=True, frozen=True)
+class Torrent:
+    title: str
+    magnet: str
+    seeders: int
+    leechers: int
+    size: str
+    uploader: str

--- a/tpb/tpb/tui.py
+++ b/tpb/tpb/tui.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from textual import events
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.containers import Container
+from textual.widgets import Button, DataTable, Footer, Header, Input, Static
+
+from .client import TPBClient
+from .exceptions import MirrorError, SearchError
+from .models import Torrent
+
+
+class TPBTuiApp(App):
+    CSS = """
+    Screen {
+        align: center middle;
+    }
+    #status {
+        height: 1;
+    }
+    #controls {
+        height: 3;
+    }
+    """
+
+    BINDINGS = [
+        Binding("q", "quit", "Quit"),
+        Binding("a", "share_selected", "Print selected magnets"),
+        Binding("enter", "show_magnet", "Show magnet"),
+        Binding("space", "toggle_selection", "Toggle selection"),
+    ]
+
+    def __init__(self, client: TPBClient, initial_query: Optional[str] = None, limit: int = 15):
+        super().__init__()
+        self.client = client
+        self.initial_query = initial_query
+        self.limit = limit
+        self._results: list[Torrent] = []
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        with Container(id="controls"):
+            yield Input(placeholder="Enter search query", id="query")
+            yield Button("Search", id="search")
+        yield Static("Ready", id="status")
+        table = DataTable(id="results")
+        table.add_columns("Idx", "Title", "Seeders", "Leechers", "Size", "Uploader")
+        table.cursor_type = "row"
+        yield table
+        yield Footer()
+
+    async def on_mount(self) -> None:
+        if self.initial_query:
+            query_widget = self.query_one("#query", Input)
+            query_widget.value = self.initial_query
+            await self.perform_search(self.initial_query)
+
+    async def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "search":
+            query = self.query_one("#query", Input).value
+            await self.perform_search(query)
+
+    async def on_input_submitted(self, event: Input.Submitted) -> None:
+        if event.input.id == "query":
+            await self.perform_search(event.value)
+
+    async def action_show_magnet(self) -> None:
+        table = self.query_one(DataTable)
+        if table.cursor_row is None:
+            return
+        magnet = self._results[table.cursor_row].magnet
+        self.query_one("#status", Static).update(f"Selected magnet: {magnet}")
+        print(magnet)
+
+    async def action_share_selected(self) -> None:
+        table = self.query_one(DataTable)
+        if not table.selected_rows:
+            return
+        magnets = [self._results[row].magnet for row in table.selected_rows]
+        output = "\n".join(magnets)
+        self.query_one("#status", Static).update(f"Shared {len(magnets)} magnets to stdout")
+        print(output)
+
+    async def action_toggle_selection(self) -> None:
+        table = self.query_one(DataTable)
+        if table.cursor_row is not None:
+            table.toggle_row(table.cursor_row)
+
+    async def perform_search(self, query: str) -> None:
+        status = self.query_one("#status", Static)
+        status.update(f"Searching for '{query}' ...")
+        table = self.query_one(DataTable)
+        table.clear(columns=True)
+        table.add_columns("Idx", "Title", "Seeders", "Leechers", "Size", "Uploader")
+        try:
+            self._results = self.client.search(query, limit=self.limit)
+        except (SearchError, MirrorError) as exc:
+            status.update(f"Search failed: {exc}")
+            return
+
+        for idx, torrent in enumerate(self._results, start=1):
+            table.add_row(
+                str(idx),
+                torrent.title,
+                str(torrent.seeders),
+                str(torrent.leechers),
+                torrent.size,
+                torrent.uploader,
+            )
+        status.update(f"Loaded {len(self._results)} results")
+
+    async def on_key(self, event: events.Key) -> None:
+        if event.key == "escape":
+            await self.action_quit()

--- a/tpb/uv.lock
+++ b/tpb/uv.lock
@@ -194,7 +194,7 @@ wheels = [
 [[package]]
 name = "tpb"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "pysocks" },
     { name = "python-gnupg" },

--- a/tpb/uv.lock
+++ b/tpb/uv.lock
@@ -1,0 +1,252 @@
+version = 1
+revision = 2
+requires-python = ">=3.12"
+
+[[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "linkify-it-py"
+version = "2.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/ae/bb56c6828e4797ba5a4821eec7c43b8bf40f69cda4d4f5f8c8a2810ec96a/linkify-it-py-2.0.3.tar.gz", hash = "sha256:68cda27e162e9215c17d786649d1da0021a451bdc436ef9e0fa0ba5234b9b048", size = 27946, upload-time = "2024-02-04T14:48:04.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/1e/b832de447dee8b582cac175871d2f6c3d5077cc56d5575cadba1fd1cccfa/linkify_it_py-2.0.3-py3-none-any.whl", hash = "sha256:6bcbc417b0ac14323382aef5c5192c0075bf8a9d6b41820a2b66371eac6b6d79", size = 19820, upload-time = "2024-02-04T14:48:02.496Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655, upload-time = "2025-08-11T07:25:49.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f", size = 57205, upload-time = "2025-08-11T07:25:47.597Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/33/9611380c2bdb1225fdef633e2a9610622310fed35ab11dac9620972ee088/platformdirs-4.5.0.tar.gz", hash = "sha256:70ddccdd7c99fc5942e9fc25636a8b34d04c24b335100223152c2803e4063312", size = 21632, upload-time = "2025-10-08T17:44:48.791Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/cb/ac7874b3e5d58441674fb70742e6c374b28b0c7cb988d37d991cde47166c/platformdirs-4.5.0-py3-none-any.whl", hash = "sha256:e578a81bb873cbb89a41fcc904c7ef523cc18284b7e3b3ccf06aca1403b7ebd3", size = 18651, upload-time = "2025-10-08T17:44:47.223Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pysocks"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload-time = "2019-09-20T02:07:35.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload-time = "2019-09-20T02:06:22.938Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/56/f013048ac4bc4c1d9be45afd4ab209ea62822fb1598f40687e6bf45dcea4/pytest-9.0.1.tar.gz", hash = "sha256:3e9c069ea73583e255c3b21cf46b8d3c56f6e3a1a8f6da94ccb0fcf57b9d73c8", size = 1564125, upload-time = "2025-11-12T13:05:09.333Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/8b/6300fb80f858cda1c51ffa17075df5d846757081d11ab4aa35cef9e6258b/pytest-9.0.1-py3-none-any.whl", hash = "sha256:67be0030d194df2dfa7b556f2e56fb3c3315bd5c8822c6951162b92b32ce7dad", size = 373668, upload-time = "2025-11-12T13:05:07.379Z" },
+]
+
+[[package]]
+name = "python-gnupg"
+version = "0.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/d0/72a14a79f26c6119b281f6ccc475a787432ef155560278e60df97ce68a86/python-gnupg-0.5.5.tar.gz", hash = "sha256:3fdcaf76f60a1b948ff8e37dc398d03cf9ce7427065d583082b92da7a4ff5a63", size = 66467, upload-time = "2025-08-04T19:26:55.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/19/c147f78cc18c8788f54d4a16a22f6c05deba85ead5672d3ddf6dcba5a5fe/python_gnupg-0.5.5-py2.py3-none-any.whl", hash = "sha256:51fa7b8831ff0914bc73d74c59b99c613de7247b91294323c39733bb85ac3fc1", size = 21916, upload-time = "2025-08-04T19:26:54.307Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4", size = 219990, upload-time = "2025-10-09T14:16:53.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl", hash = "sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd", size = 243393, upload-time = "2025-10-09T14:16:51.245Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "textual"
+version = "6.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/2f/f0b408f227edca21d1996c1cd0b65309f0cbff44264aa40aded3ff9ce2e1/textual-6.6.0.tar.gz", hash = "sha256:53345166d6b0f9fd028ed0217d73b8f47c3a26679a18ba3b67616dcacb470eec", size = 1579327, upload-time = "2025-11-10T17:50:00.038Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/b3/95ab646b0c908823d71e49ab8b5949ec9f33346cee3897d1af6be28a8d91/textual-6.6.0-py3-none-any.whl", hash = "sha256:5a9484bd15ee8a6fd8ac4ed4849fb25ee56bed2cecc7b8a83c4cd7d5f19515e5", size = 712606, upload-time = "2025-11-10T17:49:58.391Z" },
+]
+
+[[package]]
+name = "tpb"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "pysocks" },
+    { name = "python-gnupg" },
+    { name = "textual" },
+    { name = "typer" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pysocks", specifier = ">=1.7.1" },
+    { name = "python-gnupg", specifier = ">=0.5.5" },
+    { name = "textual", specifier = ">=6.6.0" },
+    { name = "typer", specifier = ">=0.20.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.1" }]
+
+[[package]]
+name = "typer"
+version = "0.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/28/7c85c8032b91dbe79725b6f17d2fffc595dff06a35c7a30a37bef73a1ab4/typer-0.20.0.tar.gz", hash = "sha256:1aaf6494031793e4876fb0bacfa6a912b551cf43c1e63c800df8b1a866720c37", size = 106492, upload-time = "2025-10-20T17:03:49.445Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/64/7713ffe4b5983314e9d436a90d5bd4f63b6054e2aca783a3cfc44cb95bbf/typer-0.20.0-py3-none-any.whl", hash = "sha256:5b463df6793ec1dca6213a3cf4c0f03bc6e322ac5e16e13ddd622a889489784a", size = 47028, upload-time = "2025-10-20T17:03:47.617Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "1.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/7a/146a99696aee0609e3712f2b44c6274566bc368dfe8375191278045186b8/uc-micro-py-1.0.3.tar.gz", hash = "sha256:d321b92cff673ec58027c04015fcaa8bb1e005478643ff4a500882eaab88c48a", size = 6043, upload-time = "2024-02-09T16:52:01.654Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/87/1f677586e8ac487e29672e4b17455758fce261de06a0d086167bb760361a/uc_micro_py-1.0.3-py3-none-any.whl", hash = "sha256:db1dffff340817673d7b466ec86114a9dc0e9d4d9b5ba229d9d60e5c12600cd5", size = 6229, upload-time = "2024-02-09T16:52:00.371Z" },
+]


### PR DESCRIPTION
## Summary
- scaffold a new `tpb` package with TPB client, models, exceptions, and JSON helper
- add Typer CLI and Textual TUI with Tor defaults, optional onion mirror, and PGP verification handling
- cover core client behaviors and JSON serialization with pytest suites

## Testing
- uv run pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921e63d74bc8326bfbabdf45f6b26bd)